### PR TITLE
Add playwright fallback

### DIFF
--- a/async_scraper.py
+++ b/async_scraper.py
@@ -136,7 +136,7 @@ async def run_scraper(urls, output_path):
     async with aiohttp.ClientSession(headers=HEADERS, connector=connector) as session:
         for i in range(0, len(urls), CHUNK_SIZE):
             batch = urls[i:i + CHUNK_SIZE]
-            print(f"\n▶ Processing batch {i // CHUNK_SIZE + 1} of {len(urls) // CHUNK_SIZE + 1}")
+            print(f"\n Processing batch {i // CHUNK_SIZE + 1} of {len(urls) // CHUNK_SIZE + 1}")
 
             tasks = [get_data(session, url) for url in batch]
             results = []
@@ -163,7 +163,7 @@ def get_unprocessed_urls():
     if os.path.exists(OUTPUT_PATH):
         existing = pd.read_csv(OUTPUT_PATH)
         done_urls = set(existing["url"].dropna())
-        print(f"🔎 Found {len(done_urls)} already processed URLs.")
+        print(f"Found {len(done_urls)} already processed URLs.")
     else:
         done_urls = set()
 
@@ -177,7 +177,7 @@ def main():
     if urls:
         asyncio.run(run_scraper(urls, OUTPUT_PATH))
     else:
-        print("✅ All URLs already processed.")
+        print("All URLs already processed.")
 
 
 if __name__ == "__main__":

--- a/async_scraper.py
+++ b/async_scraper.py
@@ -7,7 +7,6 @@ import pandas as pd
 from bs4 import BeautifulSoup
 from datetime import datetime
 from tqdm.asyncio import tqdm
-from playwright.async_api import async_playwright
 
 # CONFIG
 INPUT_PATH = "data.csv"
@@ -34,51 +33,6 @@ def parse_view_count(text):
         return None
 
 
-async def get_data_playwright(url):
-    try:
-        async with async_playwright() as p:
-            browser = await p.firefox.launch(headless=True)
-            page = await browser.new_page()
-            await page.goto(url, timeout=30000)
-
-            html = await page.content()
-            soup = BeautifulSoup(html, "html.parser")
-
-            title = soup.title.string.strip() if soup.title else None
-
-            date_match = re.search(r"'video_date_published'\s*:\s*'(\d{8})'", html)
-            upload_date = datetime.strptime(date_match.group(1), "%Y%m%d").date() if date_match else None
-
-            votes_up = None
-            span = soup.find("span", class_="votesUp")
-            if span and span.has_attr("data-rating"):
-                votes_up = int(span["data-rating"])
-
-            views = None
-            views_div = soup.find("div", class_="views")
-            if views_div:
-                count_span = views_div.find("span", class_="count")
-                if count_span:
-                    views = parse_view_count(count_span.text.strip())
-
-            categories = []
-            wrapper = soup.find("div", class_="categoriesWrapper")
-            if wrapper:
-                categories = [a.get_text(strip=True) for a in wrapper.find_all("a", class_="item")]
-
-            tags = []
-            meta = soup.find("meta", attrs={"name": "adsbytrafficjunkycontext"})
-            if meta and meta.has_attr("data-context-tag"):
-                tags = [t.strip() for t in meta["data-context-tag"].split(",")]
-
-            await browser.close()
-            return url, title, upload_date, votes_up, views, categories, tags
-
-    except Exception as e:
-        print(f"[Playwright Failed] {url} | {e}")
-        return url, None, None, None, None, None, None
-
-
 async def get_data(session, url, retries=RETRIES):
     for attempt in range(retries):
         try:
@@ -94,16 +48,17 @@ async def get_data(session, url, retries=RETRIES):
                 html = await resp.text()
                 soup = BeautifulSoup(html, "html.parser")
 
-                title = soup.title.string.strip() if soup.title else None
-
+                # Upload date
                 date_match = re.search(r"'video_date_published'\s*:\s*'(\d{8})'", html)
                 upload_date = datetime.strptime(date_match.group(1), "%Y%m%d").date() if date_match else None
 
+                # Votes up
                 votes_up = None
                 votes_span = soup.find("span", class_="votesUp")
                 if votes_span and votes_span.has_attr("data-rating"):
                     votes_up = int(votes_span["data-rating"])
 
+                # Views
                 views = None
                 views_div = soup.find("div", class_="views")
                 if views_div:
@@ -111,24 +66,34 @@ async def get_data(session, url, retries=RETRIES):
                     if count_span:
                         views = parse_view_count(count_span.text.strip())
 
+                # Categories
                 categories = []
                 wrapper = soup.find("div", class_="categoriesWrapper")
                 if wrapper:
                     categories = [a.get_text(strip=True) for a in wrapper.find_all("a", class_="item")]
 
+                # Tags
                 tags = []
                 meta = soup.find("meta", attrs={"name": "adsbytrafficjunkycontext"})
                 if meta and meta.has_attr("data-context-tag"):
                     tags = [t.strip() for t in meta["data-context-tag"].split(",")]
 
-                return url, title, upload_date, votes_up, views, categories, tags
+                # Title
+                title_tag = soup.find("meta", attrs={"property": "og:title"})
+                video_title = title_tag["content"].replace(" - Pornhub.com", "").strip() if title_tag else None
+
+                return url, upload_date, votes_up, views, categories, tags, video_title
 
         except Exception as e:
             if attempt < retries - 1:
                 await asyncio.sleep(2 ** attempt)
             else:
-                print(f"[aiohttp Failed] Falling back to Playwright: {url}")
-                return await get_data_playwright(url)
+                error_message = f"{url} | {type(e).__name__}: {e}"
+                print(f"Failed: {error_message}")
+                async with asyncio.Lock():
+                    with open("failed_urls.log", "a", encoding="utf-8") as f:
+                        f.write(error_message + "\n")
+                return url, None, None, None, None, None, None
 
 
 async def run_scraper(urls, output_path):
@@ -136,7 +101,7 @@ async def run_scraper(urls, output_path):
     async with aiohttp.ClientSession(headers=HEADERS, connector=connector) as session:
         for i in range(0, len(urls), CHUNK_SIZE):
             batch = urls[i:i + CHUNK_SIZE]
-            print(f"\n Processing batch {i // CHUNK_SIZE + 1} of {len(urls) // CHUNK_SIZE + 1}")
+            print(f"\n▶ Processing batch {i // CHUNK_SIZE + 1} of {len(urls) // CHUNK_SIZE + 1}")
 
             tasks = [get_data(session, url) for url in batch]
             results = []
@@ -145,7 +110,8 @@ async def run_scraper(urls, output_path):
                 results.append(result)
 
             batch_df = pd.DataFrame(results, columns=[
-                "url", "_title", "_upload_date", "_votes_up", "_views", "_categories", "_tags"])
+                "url", "_upload_date", "_votes_up", "_views", "_categories", "_tags", "_title"
+            ])
             batch_df["_categories"] = batch_df["_categories"].apply(lambda x: ";".join(x) if isinstance(x, list) else "")
             batch_df["_tags"] = batch_df["_tags"].apply(lambda x: ";".join(x) if isinstance(x, list) else "")
 
@@ -163,7 +129,7 @@ def get_unprocessed_urls():
     if os.path.exists(OUTPUT_PATH):
         existing = pd.read_csv(OUTPUT_PATH)
         done_urls = set(existing["url"].dropna())
-        print(f"Found {len(done_urls)} already processed URLs.")
+        print(f"🔎 Found {len(done_urls)} already processed URLs.")
     else:
         done_urls = set()
 
@@ -172,12 +138,38 @@ def get_unprocessed_urls():
     return remaining
 
 
+def get_failed_urls():
+    if not os.path.exists(OUTPUT_PATH):
+        return []
+
+    df = pd.read_csv(OUTPUT_PATH)
+    failed_df = df[df[["_upload_date", "_votes_up", "_views", "_categories", "_tags", "_title"]].isnull().all(axis=1)]
+    print(f"Found {len(failed_df)} rows with missing metadata.")
+    return failed_df["url"].dropna().tolist()
+
+
 def main():
-    urls = get_unprocessed_urls()
-    if urls:
-        asyncio.run(run_scraper(urls, OUTPUT_PATH))
-    else:
-        print("All URLs already processed.")
+    # Step 1: Process remaining new URLs
+    new_urls = get_unprocessed_urls()
+    if new_urls:
+        asyncio.run(run_scraper(new_urls, OUTPUT_PATH))
+
+    # Step 2: Retry failed rows
+    retry_urls = get_failed_urls()
+    if retry_urls:
+        print("Retrying failed metadata fetches...")
+        temp_retry_path = "retry_temp.csv"
+        asyncio.run(run_scraper(retry_urls, temp_retry_path))
+
+        # Merge retry file into final output
+        df_existing = pd.read_csv(OUTPUT_PATH).set_index("url")
+        df_retry = pd.read_csv(temp_retry_path).set_index("url")
+        df_merged = df_retry.combine_first(df_existing).reset_index()
+        df_merged.to_csv(OUTPUT_PATH, index=False)
+        os.remove(temp_retry_path)
+        print("Retried data merged into output.")
+
+    print("Scraping complete.")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+aiohappyeyeballs==2.6.1
+aiohttp==3.11.18
+aiosignal==1.3.2
 arcade==3.1.0
 attrs==25.3.0
 beautifulsoup4==4.13.4
@@ -6,7 +9,9 @@ certifi==2025.4.26
 cffi==1.17.1
 charset-normalizer==3.4.2
 click==8.1.8
+frozenlist==1.6.0
 ghp-import==2.1.0
+greenlet==3.2.2
 idna==3.10
 Jinja2==3.1.6
 Markdown==3.7
@@ -16,13 +21,17 @@ mkdocs==1.6.1
 mkdocs-autorefs==1.4.1
 mkdocs-get-deps==0.2.0
 mkdocstrings==0.29.0
+multidict==6.4.4
 numpy==2.2.6
 packaging==24.2
 pandas==2.2.3
 pathspec==0.12.1
 pillow==11.0.0
 platformdirs==4.3.6
+playwright==1.52.0
+propcache==0.3.1
 pycparser==2.22
+pyee==13.0.0
 pyglet==2.1.3
 pymdown-extensions==10.14.3
 pymunk==6.9.0
@@ -39,3 +48,4 @@ typing_extensions==4.13.0
 tzdata==2025.2
 urllib3==2.4.0
 watchdog==6.0.0
+yarl==1.20.0


### PR DESCRIPTION
This PR adds Playwright as a fallback to scrape video pages that fail with aiohttp. It uses a headless browser to handle JavaScript-heavy or protected pages, ensuring we can extract metadata even when standard requests fail. Only URLs logged as failed are retried with Playwright.